### PR TITLE
Support messaging between EPV2 circuits and communicators

### DIFF
--- a/code/game/objects/items/devices/communicator/messaging.dm
+++ b/code/game/objects/items/devices/communicator/messaging.dm
@@ -59,14 +59,20 @@
 		var/mob/observer/dead/ghost = candidate
 		who = ghost
 		im_list += list(list("address" = origin_address, "to_address" = exonet.address, "im" = text))
+		im_contacts |= candidate
 	else if(istype(candidate, /obj/item/device/communicator))
 		var/obj/item/device/communicator/comm = candidate
 		who = comm.owner
 		comm.im_contacts |= src
 		im_list += list(list("address" = origin_address, "to_address" = exonet.address, "im" = text))
+		im_contacts |= candidate
+	else if(istype(candidate, /obj/item/integrated_circuit/input/EPv2))
+		var/obj/item/integrated_circuit/input/EPv2/circuit = candidate
+		who = "Unknown"
+		im_list += list(list("address" = origin_address, "to_address" = exonet.address, "im" = text))
+		im_contacts |= circuit
+		known_devices |= circuit
 	else return
-
-	im_contacts |= candidate
 
 	if(!who)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
There was a bug which prevented texts between communicators and EPv2 circuits from displaying. Communicators could send messages to EPv2 circuits just fine, but the reverse wasn't true. Communicators would fail to display or alert for these messages. In the interest in allowing for more interesting circuits and means of interacting with them I've solved that problem.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives more use cases for circuits. For example, using an EPv2 circuit could allow for a device to discreetly message someone under certain conditions. Such as if someone got close to the device, or if someone's health had gone below a certain threshold. If someone put in the effort they could even make a replacement for the suit sensors network, once I fix circuit persistence.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 0xEFF
fix: Fixed EPv2 circuits failing to send data to communicators
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->