### PR TITLE
Adds a cooldown to emotes with sounds attached to them

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,3 +1,24 @@
+#define EMOTE_COOLDOWN 20		//Time in deciseconds that the cooldown lasts
+
+//Emote Cooldown System (it's so simple!)
+/mob/proc/handle_emote_CD(cooldown = EMOTE_COOLDOWN)
+	if(emote_cd == 3) //Spam those emotes
+		return FALSE
+	if(emote_cd == 2) // Cooldown emotes were disabled by an admin, prevent use
+		return TRUE
+	if(emote_cd == 1)  // Already on CD, prevent use
+		return TRUE
+
+	emote_cd = TRUE	// Starting cooldown
+	spawn(cooldown)
+		if(emote_cd == 2)
+			return TRUE // Don't reset if cooldown emotes were disabled by an admin during the cooldown
+		emote_cd = FALSE // Cooldown complete, ready for more!
+	return FALSE // Proceed with emote
+
+//Credit to Falseincarnate for the emote cooldown system!
+
+
 // All mobs should have custom emote, really..
 //m_type == 1 --> visual.
 //m_type == 2 --> audible

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -21,8 +21,24 @@
 
 	if(src.stat == 2.0 && (act != "deathgasp"))
 		return
-	switch(act)
 
+	//Emote Cooldown System (it's so simple!)
+	//handle_emote_CD() located in [code\modules\mob\emote.dm]
+	var/on_CD = FALSE
+	act = lowertext(act)
+
+	switch(act)
+		if("ping", "buzz", "beep", "yes", "no", "scream", "giggle", "laugh", "cough", "flip", "gasp", "dwoop", "rcough", "rsneeze", "sneeze", "snore")
+			on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm
+		else
+			on_CD = FALSE	//If it doesn't induce the cooldown, we won't check for the cooldown
+
+	if(on_CD == 1)		// Check if we need to suppress the emote attempt.
+		return			// Suppress emote, you're still cooling off.
+
+
+
+	switch(act)
 		if ("airguitar")
 			if (!src.restrained())
 				message = "is strumming the air and headbanging like a safari chimp."
@@ -577,13 +593,13 @@
 			if (!src.restrained())
 				message = "raises a hand."
 			m_type = 1
-			
+
 		if("crack")
 			if(!restrained())
 				message = "cracks [T.his] knuckles."
 				playsound(src, 'sound/voice/knuckles.ogg', 50, 1)
 				m_type = 1
-				
+
 		if("shake")
 			message = "shakes [T.his] head."
 			m_type = 1

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -8,6 +8,23 @@
 	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
 		act = copytext(act,1,length(act))
 
+	//Emote Cooldown System (it's so simple!)
+	//handle_emote_CD() located in [code\modules\mob\emote.dm]
+	var/on_CD = FALSE
+	act = lowertext(act)
+	switch(act)
+		//Cooldown-inducing emotes
+		if("law","beep","buzz","halt","Dwoop","halt","fanfare","sad","ping","yes","no")		//halt is exempt because it's used to stop criminal scum //WHOEVER THOUGHT THAT WAS A GOOD IDEA IS GOING TO GET SHOT.
+			on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm
+		//Everything else, including typos of the above emotes
+		else
+			on_CD = 0	//If it doesn't induce the cooldown, we won't check for the cooldown
+
+	if(on_CD == 1)		// Check if we need to suppress the emote attempt.
+		return			// Suppress emote, you're still cooling off.
+	//--FalseIncarnate
+
+
 	switch(act)
 		if ("me")
 			if (src.client)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -143,6 +143,8 @@
 
 	var/in_throw_mode = 0
 
+	var/emote_cd = 0		// Used to supress emote spamming. 1 if on CD, 2 if disabled by admin (manually set), else 0
+
 	var/inertia_dir = 0
 
 	var/music_lastplayed = "null"


### PR DESCRIPTION
Ported from Paradise, credit goes towards @FalseIncarnate 


## About The Pull Request

Adds an emote for almost every sound-based emote to humanoids and synthetics. The exception is the *snap emote.

## Why It's Good For The Game

Emote spam is bad and makes me want to cry.

:cl:
add: A new emote cooldown system is in effect for audible emotes.
/:cl:
