### PR TITLE
New admin verb: Sate

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -80,6 +80,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/free_slot,			//frees slot for chosen job,
 	/client/proc/cmd_admin_change_custom_event,
 	/client/proc/cmd_admin_rejuvenate,
+	/client/proc/cmd_sate,
 	/client/proc/toggleghostwriters,
 	/client/proc/toggledrones,
 	/datum/admins/proc/show_skills,

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -140,6 +140,7 @@ var/list/debug_verbs = list (
         ,/client/proc/kaboom
         ,/client/proc/cmd_admin_areatest
         ,/client/proc/cmd_admin_rejuvenate
+		,/client/proc/cmd_sate
         ,/datum/admins/proc/show_traitor_panel
         ,/client/proc/print_jobban_old
         ,/client/proc/print_jobban_old_filter

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -545,6 +545,42 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		alert("Admin revive disabled")
 	feedback_add_details("admin_verb","REJU") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/cmd_sate(mob/living/carbon/M as mob in human_mob_list)
+	set category = "Admin"
+	set name = "Sate their needs"
+	set desc = "Sate their hunger and thirst."
+	if(!holder)
+		to_chat(src, "Only administrators may use this command.")
+		return
+	if(!mob)
+		to_chat(src, "There are currently no valid mobs in the world.")
+		return
+	if(!istype(M))
+		alert("You can only sate a carbon's needs.")
+		return
+	var/custom_value = alert("Customize or just set it to 400\nCurrently:\nNutrition: [M.nutrition]\nHydration: [M.hydration]", "Modifying nutrition and hydration", "400", "Custom", "Cancel")
+	switch(custom_value)
+		if("400")
+			M.set_nutrition(400)
+			M.set_hydration(400)
+			log_admin("[key_name(usr)] has sated [key_name(M)]'s needs.")
+			message_admins("<font color='red'>Admin [key_name_admin(usr)] has sated [key_name_admin(M)]'s needs!</font>", 1)
+			feedback_add_details("admin_verb", "SATE")
+		if("Custom")
+			var/nutrition = input(usr, "How much nutrition (current:[M.nutrition])\nSetting to 0 or cancelling out won't modify it", "Setting nutrition") as null|num
+			var/hydration = input(usr, "How much hydration (current:[M.hydration])\nSetting to 0 or cancelling out won't modify it", "Setting hydration") as null|num
+			if(nutrition)
+				M.set_nutrition(nutrition)
+			if(hydration)
+				M.set_hydration(hydration)
+			if(!nutrition && !hydration)
+				return
+			log_admin("[key_name(usr)] has modified [key_name(usr)]'s sate, nutrition: [nutrition ? nutrition : M.nutrition] and hydration: [hydration ? hydration : M.hydration].")
+			message_admins("<font color='red'>Admin [key_name_admin(usr)] has modified [key_name_admin(usr)]'s sate, nutrition: [nutrition ? nutrition : M.nutrition] and hydration: [hydration ? hydration : M.hydration]</font>")
+			feedback_add_details("admin_verb", "SATE")
+		else
+			return
+
 /client/proc/cmd_admin_create_centcom_report()
 	set category = "Special Verbs"
 	set name = "Create Command Report"

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -20,3 +20,5 @@ theflagbearer - Code Wizard
 artofwasd - Code Wizard
 slayingcreepers - Code Wizard
 n8toe - Developer
+
+SandPoot - Host

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -20,5 +20,3 @@ theflagbearer - Code Wizard
 artofwasd - Code Wizard
 slayingcreepers - Code Wizard
 n8toe - Developer
-
-SandPoot - Host


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows admins to quickly modify some mob's nutrition and hydration vars quickly.
![image](https://user-images.githubusercontent.com/43283559/116017352-bf5d0300-a615-11eb-816b-f3a12329df9b.png)
![image](https://user-images.githubusercontent.com/43283559/116017375-ca179800-a615-11eb-9b2f-d5be90bd8e10.png)
![image](https://user-images.githubusercontent.com/43283559/116017382-d00d7900-a615-11eb-98f0-4f5454d0c0a2.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admins getting hungry while solving your issues.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Sate admin verb, now admins can quickly modify a mob's nutrition and hydration quickly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->