### PR TITLE
changed outfits for engineering

### DIFF
--- a/code/game/jobs/job/emergency.dm
+++ b/code/game/jobs/job/emergency.dm
@@ -57,7 +57,7 @@
 	alt_titles = list("Firefighter/EMT")
 	minimum_character_age = 18
 	minimal_player_age = 3
-	outfit_type = /decl/hierarchy/outfit/job/engineering/engineer
+	outfit_type = /decl/hierarchy/outfit/job/engineering/atmos
 */
 /datum/job/atmos
 	title = "Maintenance Worker"
@@ -71,7 +71,7 @@
 	spawn_positions = 2
 	supervisors = "the maintenance director"
 	selection_color = "#5B4D20"
-	idtype = /obj/item/weapon/card/id/engineering/atmos
+	idtype = /obj/item/weapon/card/id/engineering/engineer
 	wage = 500
 	synth_wage = 250
 


### PR DESCRIPTION
## About The Pull Request

Maintenance workers should spawn with proper outfits

## Why It's Good For The Game

Electrician should not get firesuit from spawn. Nobody should get it honestly. It's not an outfit for walking around, it's bulky and heavy

## Changelog
:cl:
tweak: tweaked outfit for maintenance worker and for commented out firefighter
balance: Electrician should not get firesuit from spawn
fix: fixed outfit for engineer
code: changed some code for jobs
/:cl: