### PR TITLE
Jesus Fix

### DIFF
--- a/code/modules/mob/event_mobs.dm
+++ b/code/modules/mob/event_mobs.dm
@@ -13,8 +13,6 @@
 	src.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(src), slot_shoes)
 	src.equip_to_slot_or_del(new /obj/item/clothing/under/pants/baggy/white(src), slot_w_uniform)
 	src.equip_to_slot_or_del(new /obj/item/clothing/suit/kimono(src), slot_wear_suit)
-	src.equip_to_slot_or_del(new /obj/item/weapon/storage/bible/booze(src), slot_r_hand)
-	src.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater(src), slot_l_hand)
 	name = "Jesus Christ"
 	real_name = "Jesus Christ"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removed the Bible and Holy Water that the Jesus Mob spawns with. Staff always delete the items rather than pick them up. One less step to using a DEBUG mob

## Why It's Good For The Game

Saves a little time for Staff

## Changelog
:cl:
Removed the Bible and Holy Water from Jesus' spawn items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->