### PR TITLE
enabled civilians to pick clown and mime outfit

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_mask.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_mask.dm
@@ -22,6 +22,30 @@
 	path = /obj/item/clothing/mask/surgical
 	cost = 2
 
+/datum/gear/mask/clowncivilian
+	display_name = "clown mask"
+	path = /obj/item/clothing/mask/gas/clown_hat
+	allowed_roles = list("Civilian")
+	cost=5 //it is sort of rare
+
+/datum/gear/mask/mimecivilian
+	display_name = "mime mask"
+	path = /obj/item/clothing/mask/gas/mime
+	allowed_roles = list("Civilian")
+	cost=5 //it is sort of rare
+
+/datum/gear/mask/clowncivilian2
+	display_name = "clown mask (alternative)"
+	path = /obj/item/clothing/mask/gas/sexyclown
+	allowed_roles = list("Civilian")
+	cost=5 //it is sort of rare
+
+/datum/gear/mask/mimecivilian2
+	display_name = "mime mask (alternative)"
+	path = /obj/item/clothing/mask/gas/sexymime
+	allowed_roles = list("Civilian")
+	cost=5 //it is sort of rare
+
 /datum/gear/mask/ipc_monitor
 	display_name = "display monitor (Full Body Prosthetic)"
 	path = /obj/item/clothing/mask/monitor

--- a/code/modules/client/preference_setup/loadout/loadout_shoes.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_shoes.dm
@@ -233,6 +233,18 @@
 	path = /obj/item/clothing/shoes/boots/winter/hydro
 	allowed_roles = list("Botanist", "Xenobiologist")
 
+/datum/gear/shoes/clowncivilian
+	display_name = "clown shoes"
+	path = /obj/item/clothing/shoes/clown_shoes
+	allowed_roles = list("Civilian")
+	cost=5 //it is sort of rare
+
+/datum/gear/shoes/mimecivilian
+	display_name = "mime shoes"
+	path = /obj/item/clothing/shoes/mime
+	allowed_roles = list("Civilian")
+	cost=5 //it is sort of rare
+
 /datum/gear/shoes/boots/stylish
 	display_name = "stylish boots selection"
 	path = /obj/item/clothing/shoes/boots/stylish

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -687,6 +687,18 @@
 	display_name = "disheveled suit"
 	path = /obj/item/clothing/under/disheveled
 
+/datum/gear/uniform/clowncivilian
+	display_name = "clown suit"
+	path = /obj/item/clothing/under/rank/clown
+	allowed_roles = list("Civilian")
+	cost=5 //it is sort of rare
+
+/datum/gear/uniform/mimecivilian
+	display_name = "mime suit"
+	path = /obj/item/clothing/under/mime
+	allowed_roles = list("Civilian")
+	cost=5 //it is sort of rare
+
 /// Comment the items below out one week after the "Ports clothing from Polaris + Additional" PR is merged! Excxlusivity! ///
 
 /datum/gear/uniform/whitegown


### PR DESCRIPTION
## About The Pull Request

Added clown and mime outfit as options for civilians

Tested on local installation, it works.

![image](https://user-images.githubusercontent.com/864126/139529295-afbbc5d9-5658-4992-a15d-b423405daaf3.png)

![image](https://user-images.githubusercontent.com/864126/139529315-1ae43c56-9cd0-47d3-afba-feb36e853b89.png)


## Why It's Good For The Game

People will get a motivation to join as civilians. You may RP as travelling clown, or mime if you like, but be a civilian

## Changelog
:cl:
add: Added clown and mime clothing to outfit choice for civilians
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->