### PR TITLE
You can put turned camera to backpack

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -296,7 +296,9 @@ var/global/photo_count = 0
 
 
 /obj/item/device/camera/afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
-	if(!on || !pictures_left || ismob(target.loc)) return
+
+	if(!on || !pictures_left || ismob(target.loc) || istype(target.loc, /obj/item/weapon/storage) ) return
+	if(user.contains(target) || istype(target, /obj/screen)) return
 	captureimage(target, user, flag)
 
 	playsound(loc, pick('sound/items/polaroid1.ogg', 'sound/items/polaroid2.ogg'), 75, 1, -3)


### PR DESCRIPTION
You can put turned camera into backpack without accidentally taking photo

## About The Pull Request

A small QoL fix. You can now put camera into storage and it won't take photo by accident. Inspired by similar PR from CM-SS13 : https://gitlab.com/cmdevs/colonial-warfare/-/merge_requests/2207/diffs (adapted code to this build)

## Why It's Good For The Game

Wasting photos is bad.

## Changelog
:cl:
fix: Cameras will no longer take photos when you put them in storage items
fix: Cameras will no longer take photos when you attempt to put them in inventory slots
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->