### PR TITLE
Fixed arcade machine

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -51,16 +51,16 @@
 		qdel(src)
 
 /obj/machinery/computer/arcade/proc/prizevend()
-	if(!contents.len)
-		var/prizeselect = pickweight(prizes)
-		new prizeselect(src.loc)
-
-		if(istype(prizeselect, /obj/item/clothing/suit/syndicatefake)) //Helmet is part of the suit
-			new	/obj/item/clothing/head/syndicatefake(src.loc)
-
-	else
-		var/atom/movable/prize = pick(contents)
-		prize.loc = src.loc
+	//if(!(contents-circuit).len)
+	var/prizeselect = pickweight(prizes)
+	new prizeselect(src.loc)
+	if(istype(prizeselect, /obj/item/weapon/gun/projectile/revolver/capgun)) //Ammo comes with the gun
+		new /obj/item/projectile/bullet/pistol/cap(src.loc)
+	if(istype(prizeselect, /obj/item/clothing/suit/syndicatefake)) //Helmet is part of the suit
+		new	/obj/item/clothing/head/syndicatefake(src.loc)
+	//else
+	//	var/atom/movable/prize = pick(contents-circuit)
+	//	prize.loc = src.loc
 
 /obj/machinery/computer/arcade/attack_ai(mob/user as mob)
 	return attack_hand(user)
@@ -111,6 +111,9 @@
 	var/gameover = 0
 	var/blocked = 0 //Player cannot attack/heal while set
 	var/turtle = 0
+
+/obj/machinery/computer/arcade/battle/free
+	requires_token = FALSE
 
 /obj/machinery/computer/arcade/battle/New()
 	..()
@@ -361,6 +364,9 @@
 	var/last_spaceport_action = ""
 	var/gameStatus = ORION_STATUS_START
 	var/canContinueEvent = 0
+
+/obj/machinery/computer/arcade/orion_trail/free
+	requires_token = FALSE
 
 /obj/machinery/computer/arcade/orion_trail/New()
 	..()

--- a/code/game/objects/items/weapons/circuitboards/computer/computer.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/computer.dm
@@ -92,10 +92,20 @@
 	build_path = /obj/machinery/computer/arcade/battle
 	origin_tech = list(TECH_DATA = 1)
 
+/obj/item/weapon/circuitboard/arcade/battlefree
+	name = T_BOARD("battle arcade machine unlocked")
+	build_path = /obj/machinery/computer/arcade/battle/free
+	origin_tech = list(TECH_DATA = 4)
+
 /obj/item/weapon/circuitboard/arcade/orion_trail
 	name = T_BOARD("orion trail arcade machine")
 	build_path = /obj/machinery/computer/arcade/orion_trail
 	origin_tech = list(TECH_DATA = 1)
+
+/obj/item/weapon/circuitboard/arcade/orion_trailfree
+	name = T_BOARD("orion trail arcade machine unlocked")
+	build_path = /obj/machinery/computer/arcade/orion_trail/free
+	origin_tech = list(TECH_DATA = 4)
 
 /obj/item/weapon/circuitboard/turbine_control
 	name = T_BOARD("turbine control console")

--- a/code/modules/research/designs/circuits.dm
+++ b/code/modules/research/designs/circuits.dm
@@ -36,6 +36,22 @@
 	sort_string = "MAAAA"
 	protected = TRUE
 
+/datum/design/circuit/arcademachinefree
+	name = "battle arcade unlocked"
+	id = "arcademachineunlocked"
+	req_tech = list(TECH_DATA = 4)
+	build_path = /obj/item/weapon/circuitboard/arcade/battlefree
+	sort_string = "MAAAL"
+	protected = TRUE
+
+/datum/design/circuit/oriontrailfree
+	name = "orion trail arcade unlocked"
+	id = "oriontrailunlocked"
+	req_tech = list(TECH_DATA = 4)
+	build_path = /obj/item/weapon/circuitboard/arcade/orion_trailfree
+	sort_string = "MAAAN"
+	protected = TRUE
+
 /datum/design/circuit/jukebox
 	name = "jukebox"
 	id = "jukebox"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Arcade machine now correctly vends prizes, but not circuit board. Added boards for "free arcade machines" and construction for them. Boards are obtainable from RnD, after reaching high level (they have same requirement as AI upload console).

## Why It's Good For The Game

Fixed error when arcade gave own board. Free arcade machine is a reward for researcher for reaching high level. Also, other people may ask for it too. 

## Changelog
:cl:
add: Added boards for "free arcade machines" and construction for them. Boards are obtainable from RnD, after reaching high level (they have same requirement as AI upload console).
fix: Arcade machine now correctly vends prizes, but not circuit board
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->