### PR TITLE
Changed infestation event. Vermins are now spawned in actual areas on map

### DIFF
--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -1,12 +1,12 @@
 #define LOC_KITCHEN 0
-#define LOC_ATMOS 1
+#define LOC_FITNESS 1
 #define LOC_CHAPEL 2
-#define LOC_LIBRARY 3
-#define LOC_HYDRO 4
-#define LOC_VAULT 5
-#define LOC_CONSTR 6
-#define LOC_TECH 7
-#define LOC_GARDEN 8
+#define LOC_PARK 3
+#define LOC_RESEARCH 4
+#define LOC_SECURITY 5
+#define LOC_CARGO 6
+#define LOC_MEDICAL 7
+#define LOC_CITYHALL 8
 
 #define VERM_MICE 0
 #define VERM_LIZARDS 1
@@ -29,30 +29,30 @@
 		if(LOC_KITCHEN)
 			spawn_area_type = /area/crew_quarters/kitchen
 			locstring = "the kitchen"
-		if(LOC_ATMOS)
-			spawn_area_type = /area/engineering/atmos
-			locstring = "atmospherics"
+		if(LOC_FITNESS)
+			spawn_area_type = /area/crew_quarters/fitness
+			locstring = "fitness area"
 		if(LOC_CHAPEL)
 			spawn_area_type = /area/chapel/main
 			locstring = "the chapel"
-		if(LOC_LIBRARY)
-			spawn_area_type = /area/library
-			locstring = "the library"
-		if(LOC_HYDRO)
-			spawn_area_type = /area/hydroponics
-			locstring = "hydroponics"
-		if(LOC_VAULT)
-			spawn_area_type = /area/security/nuke_storage
-			locstring = "the vault"
-		if(LOC_CONSTR)
-			spawn_area_type = /area/construction
-			locstring = "the construction area"
-		if(LOC_TECH)
-			spawn_area_type = /area/storage/tech
-			locstring = "technical storage"
-		if(LOC_GARDEN)
-			spawn_area_type = /area/hydroponics/garden
-			locstring = "the public garden"
+		if(LOC_PARK)
+			spawn_area_type = /area/planets/Geminus/outdoor/park
+			locstring = "the recreation area"
+		if(LOC_RESEARCH)
+			spawn_area_type = /area/rnd/research_foyer
+			locstring = "the research facility"
+		if(LOC_SECURITY)
+			spawn_area_type = /area/security/main
+			locstring = "the police department"
+		if(LOC_CARGO)
+			spawn_area_type = /area/quartermaster/storage
+			locstring = "the supply terminal"
+		if(LOC_MEDICAL)
+			spawn_area_type = /area/medical/medbay2
+			locstring = "the medical area"
+		if(LOC_CITYHALL)
+			spawn_area_type = /area/planets/Geminus/indoor/city_hall
+			locstring = "the city hall"
 
 	for(var/areapath in typesof(spawn_area_type))
 		var/area/A = locate(areapath)
@@ -93,16 +93,18 @@
 
 
 /datum/event/infestation/announce()
+	//should it be announced in public? maybe, use global_announcer.autosay(warnmessage, "Pest Control", "Engineering")
 	command_announcement.Announce("Bioscans indicate that [vermstring] have been breeding in [locstring]. Clear them out, before this starts to affect productivity.", "Vermin infestation")
 
 #undef LOC_KITCHEN
-#undef LOC_ATMOS
+#undef LOC_FITNESS
 #undef LOC_CHAPEL
-#undef LOC_LIBRARY
-#undef LOC_HYDRO
-#undef LOC_VAULT
-#undef LOC_TECH
-#undef LOC_GARDEN
+#undef LOC_PARK
+#undef LOC_RESEARCH
+#undef LOC_SECURITY
+#undef LOC_CARGO
+#undef LOC_MEDICAL
+#undef LOC_CITYHALL
 
 #undef VERM_MICE
 #undef VERM_LIZARDS

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -21,3 +21,4 @@ artofwasd - Code Wizard
 slayingcreepers - Code Wizard
 n8toe - Developer
 APsychonaut - Code Wizard
+semorerith - Host


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updated infestation event, varmins should be spawned in areas available on current map. They may appear in police dept, medbay, city hall, supply area, park, research area, gym, kitchen, chapel. It compiles

## Why It's Good For The Game

Infestation event failed to spawn vermins on areas which were not present on map. Now it should be fixed

## Changelog
:cl:
code: changed infestation event code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->