### PR TITLE
removed cyberpunk jukebox

### DIFF
--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -62,6 +62,9 @@ datum/track/New(var/title_name, var/audio)
 		new/datum/track("The Rebel Path", 'sound/music/disco/The Rebel Path.ogg'),
 		new/datum/track("Yacht Song", 'sound/music/disco/Yacht Song.ogg'),
 		new/datum/track("Wake Up", 'sound/music/disco/Wake Up.ogg'),
+		// 'RAVE' SONGS
+		new/datum/track("It Went", 'sound/music/disco/It Went.ogg'),
+		new/datum/track("Jurassic Park", 'sound/music/disco/Jurassic Park.ogg')
 	)
 
 	// Only visible if hacked
@@ -316,7 +319,7 @@ datum/track/New(var/title_name, var/audio)
 	if(playing)
 		StartPlaying()
 	updateDialog()
-
+/*
 /obj/machinery/media/jukebox/cyberpunk
 	name = "Punkmaster 9077 jukebox"
 	desc = "An immense, standalone touchscreen on a swiveling base, equipped with phased array speakers. Embossed on one corner of the ultrathin bezel is the brand name, 'Punkmaster 9077'."
@@ -362,3 +365,4 @@ datum/track/New(var/title_name, var/audio)
 		new/datum/track("GR4VES", 'sound/music/disco/GR4VES.ogg'),
 		new/datum/track("Major Crimes", 'sound/music/disco/Major Crimes.ogg')
 	)
+*/

--- a/code/game/objects/items/weapons/circuitboards/other.dm
+++ b/code/game/objects/items/weapons/circuitboards/other.dm
@@ -52,7 +52,7 @@
 							/obj/item/weapon/stock_parts/capacitor = 1,
 							/obj/item/weapon/stock_parts/console_screen = 1,
 							/obj/item/stack/cable_coil = 1)
-
+/*
 /obj/item/weapon/circuitboard/jukebox/cyberpunk
 	name = T_BOARD("Cyberpunk Jukebox")
 	build_path = /obj/machinery/media/jukebox/cyberpunk
@@ -62,7 +62,7 @@
 							/obj/item/weapon/stock_parts/capacitor = 1,
 							/obj/item/weapon/stock_parts/console_screen = 1,
 							/obj/item/stack/cable_coil = 1)
-
+*/
 /obj/item/weapon/circuitboard/reagentgrinder
 	name = T_BOARD("All-in-one Grinder")
 	build_path = /obj/machinery/reagentgrinder

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1094,7 +1094,7 @@ CIRCUITS BELOW
 	build_path = /obj/item/weapon/circuitboard/jukebox
 	sort_string = "MAAAB"
 	protected = TRUE
-
+/*
 /datum/design/circuit/jukebox/cyberpunk
 	name = "cyberpunk jukebox"
 	id = "cyberpunkjukebox"
@@ -1102,7 +1102,7 @@ CIRCUITS BELOW
 	build_path = /obj/item/weapon/circuitboard/jukebox/cyberpunk
 	sort_string = "MAAAC"
 	protected = TRUE
-
+*/
 /datum/design/circuit/seccamera
 	name = "security camera monitor"
 	id = "seccamera"


### PR DESCRIPTION
I removed (commented out) the redundant cyberpunk jukebox and moved the rave music to normal jukebox, why? because for now it's not necessary to have a second jukebox playing the same music and shitty electronic rock, but I think we should add a boombox sprite and add some hiphop music and rap shit to replace the cyberpunk one in the future.