### PR TITLE
Fix Fall Damage

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -384,7 +384,7 @@
 		A.fall_impact(hit_atom, damage_min, damage_max, silent = TRUE)
 
 // Take damage from falling and hitting the ground
-/mob/living/fall_impact(var/atom/hit_atom, var/damage_min = 60, var/damage_max = 100, var/silent = FALSE, var/planetary = FALSE)
+/mob/living/fall_impact(var/atom/hit_atom, var/damage_min = 10, var/damage_max = 15, var/silent = FALSE, var/planetary = FALSE)
 	var/turf/landing = get_turf(hit_atom)
 	if(planetary && src.CanParachute())
 		if(!silent)


### PR DESCRIPTION
Changed:
Fall damage from 60-100
TO
10-15
It is important to note, that when you fall, you get hit 10 times in various locations. SO MAXIMUM you take 150 damage (critical, unconcious).