### PR TITLE
Fix convayors

### DIFF
--- a/code/modules/persistence/persistence.dm
+++ b/code/modules/persistence/persistence.dm
@@ -195,11 +195,13 @@
 /obj/structure/safe
 	unique_save_vars = list("open","tumbler_1_pos","tumbler_1_open","tumbler_2_pos","tumbler_2_open","dial")
 
-
+/obj/machinery/conveyor
+	unique_save_vars = list("forwards")
+	
 /obj/structure/on_persistence_load()
 	update_connections()
 	update_icon()
-
+	
 // Don't save list - Better to keep a track of things here.
 
 /mob

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -23,7 +23,7 @@
 	var/list/affecting	// the list of all items that will be moved this ptick
 	var/id = ""			// the control ID	- must match controller ID
 
-	unique_save_vars = list("id")
+	unique_save_vars = list("id","forwards")
 
 /obj/machinery/conveyor/centcom_auto
 	id = "round_end_belt"
@@ -188,7 +188,7 @@
 	var/list/conveyors		// the list of converyors that are controlled by this switch
 	anchored = 1
 
-	unique_save_vars = list("id")
+	unique_save_vars = list("id","forwards")
 
 /obj/machinery/conveyor_switch/initialize()
 	..()


### PR DESCRIPTION
Added:
"forwards" variable to the list of unique saved variables for convayor belts. Now the direction they push items saves instead of reverting to "2" or "South" every round.